### PR TITLE
Add nagios 4 directives

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -206,6 +206,11 @@ Nagios configuration file parameter.
 
 Nagios configuration file parameter.
 
+##### `minimum_importance`
+
+(*Property:* This attribute represents concrete state on the target system.)
+
+Nagios configuration file parameter.
 ##### `mode`
 
 The desired mode of the config file for this `nagios_contact` resource.
@@ -527,6 +532,12 @@ Nagios configuration file parameter.
 Nagios configuration file parameter.
 
 ##### `icon_image_alt`
+
+(*Property:* This attribute represents concrete state on the target system.)
+
+Nagios configuration file parameter.
+
+##### `importance`
 
 (*Property:* This attribute represents concrete state on the target system.)
 
@@ -1290,6 +1301,12 @@ Nagios configuration file parameter.
 
 Nagios configuration file parameter.
 
+##### `importance`
+
+(*Property:* This attribute represents concrete state on the target system.)
+
+Nagios configuration file parameter.
+
 ##### `initial_state`
 
 (*Property:* This attribute represents concrete state on the target system.)
@@ -1375,6 +1392,12 @@ The desired owner of the config file for this `nagios_service` resource.
 NOTE: If the target file is explicitly managed by a file resource in your manifest, this parameter has no effect. If a parent directory of the target is managed by a recursive file resource, this limitation does not apply (i.e., this parameter takes precedence, and if purge is used, the target file is exempt).
 
 ##### `parallelize_check`
+
+(*Property:* This attribute represents concrete state on the target system.)
+
+Nagios configuration file parameter.
+
+##### `parents`
 
 (*Property:* This attribute represents concrete state on the target system.)
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -211,6 +211,7 @@ Nagios configuration file parameter.
 (*Property:* This attribute represents concrete state on the target system.)
 
 Nagios configuration file parameter.
+
 ##### `mode`
 
 The desired mode of the config file for this `nagios_contact` resource.

--- a/lib/puppet/external/nagios/base.rb
+++ b/lib/puppet/external/nagios/base.rb
@@ -312,7 +312,7 @@ class Nagios::Base
 
   # object types
   newtype :host do
-    setparameters :host_name, :alias, :display_name, :address, :parents,
+    setparameters :host_name, :alias, :display_name, :address, :parents, :importance,
                   :hostgroups, :check_command, :initial_state, :max_check_attempts,
                   :check_interval, :retry_interval, :active_checks_enabled,
                   :passive_checks_enabled, :check_period, :obsess_over_host,
@@ -343,11 +343,11 @@ class Nagios::Base
   newtype :service do
     attach host: :host_name
     setparameters :host_name, :hostgroup_name, :service_description,
-                  :display_name, :servicegroups, :is_volatile, :check_command,
-                  :initial_state, :max_check_attempts, :check_interval, :retry_interval,
-                  :normal_check_interval, :retry_check_interval, :active_checks_enabled,
-                  :passive_checks_enabled, :parallelize_check, :check_period,
-                  :obsess_over_service, :check_freshness, :freshness_threshold,
+                  :display_name, :parents, :importance, :servicegroups, :is_volatile,
+                  :check_command, :initial_state, :max_check_attempts, :check_interval,
+                  :retry_interval, :normal_check_interval, :retry_check_interval,
+                  :active_checks_enabled, :passive_checks_enabled, :parallelize_check,
+                  :check_period, :obsess_over_service, :check_freshness, :freshness_threshold,
                   :event_handler, :event_handler_enabled, :low_flap_threshold,
                   :high_flap_threshold, :flap_detection_enabled, :flap_detection_options,
                   :process_perf_data, :failure_prediction_enabled, :retain_status_information,
@@ -371,7 +371,7 @@ class Nagios::Base
   end
 
   newtype :contact do
-    setparameters :contact_name, :alias, :contactgroups,
+    setparameters :contact_name, :alias, :contactgroups, :minimum_importance,
                   :host_notifications_enabled, :service_notifications_enabled,
                   :host_notification_period, :service_notification_period,
                   :host_notification_options, :service_notification_options,


### PR DESCRIPTION
Object directives new to nagios 4 are not available. Namely importance for hosts & services, parents for services, and minimum_importance for contacts. See: https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/4/en/objectdefinitions.html green directives are new.